### PR TITLE
FIX Ensure there is an error response if composers autoloader cant be found

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -11,8 +11,9 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 } elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
 } else {
+    header('HTTP/1.1 500 Internal Server Error');
     echo "autoload.php not found";
-    die;
+    exit (1);
 }
 
 // Build request and detect flush


### PR DESCRIPTION
At the moment, if no composer auto-loader is found the site returns a 200 response.

This change sends a 500 response and an exit code.