### PR TITLE
FIX remove linting error for dependents' benefit

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,7 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 } else {
     header('HTTP/1.1 500 Internal Server Error');
     echo "autoload.php not found";
-    exit (1);
+    exit(1);
 }
 
 // Build request and detect flush


### PR DESCRIPTION
This module is a recipe, and as such supplies the index file for many many dependent projects (modules). This linting error causes build failures in said modules, even when using `silverstripe/framework`:`phpcs.xml.dist` for configuration (which many modules base their configurations from).