### PR TITLE
Swap order of autoload searching

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -6,10 +6,10 @@ use SilverStripe\Core\CoreKernel;
 use SilverStripe\Core\Startup\ErrorControlChainMiddleware;
 
 // Find autoload.php
-if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-    require __DIR__ . '/vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
 } else {
     header('HTTP/1.1 500 Internal Server Error');
     echo "autoload.php not found";


### PR DESCRIPTION
Now that `index.php` lives in `public`, `vendor/autoload.php` is much more likely to be in the parent dir than the current one, so we should check this first...

Perhaps we shouldn't even look in the current dir?