### PR TITLE
Change order of autoload file import

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -6,10 +6,10 @@ use SilverStripe\Core\CoreKernel;
 use SilverStripe\Core\Startup\ErrorControlChainMiddleware;
 
 // Find autoload.php
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require __DIR__ . '/../vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/vendor/autoload.php')) {
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require __DIR__ . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
 } else {
     header('HTTP/1.1 500 Internal Server Error');
     echo "autoload.php not found";


### PR DESCRIPTION
This will ensure the autoload file is first searched for within the project itself, rather than outside of it.