### PR TITLE
Update branch alias on master to 5.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
             "install-frameworkmissing.html"
         ],
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "5.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
Related to our decision to retag recipe to 4, the next version of recipe will be 5, not 2.

# Related issue
* https://github.com/silverstripeltd/open-sourcerers/issues/31