### PR TITLE
FIX Use Injector to create PasswordValidators

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -4,7 +4,7 @@ use SilverStripe\Security\PasswordValidator;
 use SilverStripe\Security\Member;
 
 // remove PasswordValidator for SilverStripe 5.0
-$validator = new PasswordValidator();
+$validator = PasswordValidator::create();
 
 $validator->minLength(8);
 $validator->checkHistoricalPasswords(6);


### PR DESCRIPTION
By using `new` to instantiate the `PasswordValidator` we make it needlessly difficult for modules to inject a new `PasswordValidator` into an installation.