### PR TITLE
NEW: Set default database charset to utf8mb4

### DIFF
--- a/app/_config/database.yml
+++ b/app/_config/database.yml
@@ -1,0 +1,8 @@
+---
+Name: myproject-database
+---
+SilverStripe\ORM\Connect\MySQLDatabase:
+  connection_charset: utf8mb4
+  connection_collation: utf8mb4_unicode_ci
+  charset: utf8mb4
+  collation: utf8mb4_unicode_ci


### PR DESCRIPTION
This will switch for new projects without breaking APIs in 
upgrades.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/8062