### PR TITLE
MINOR Get recipe-core to default to `_resources` for exposing assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /.env
 /vendor/
 /themes/simple/
-/resources/
-/public/resources/
+/_resources/
+/public/_resources/

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         ],
         "branch-alias": {
             "4.x-dev": "4.4.x-dev"
-        }
+        },
+        "resources-dir": "_resources"
     },
     "config": {
         "process-timeout": 600

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,1 +1,1 @@
-/resources/
+/_resources/


### PR DESCRIPTION
SilverStripe 4.4 should default to using `_resources` for expose assets.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/7932