### PR TITLE
FIX Ensure that the PasswordValidator is registered with Injector

### DIFF
--- a/app/_config.php
+++ b/app/_config.php
@@ -1,0 +1,9 @@
+<?php
+
+use SilverStripe\Security\PasswordValidator;
+use SilverStripe\Security\Member;
+
+// remove PasswordValidator for SilverStripe 5.0
+$validator = PasswordValidator::create();
+// Settings are registered via Injector configuration - see passwords.yml in framework
+Member::set_password_validator($validator);


### PR DESCRIPTION
We still need to register the password validator, otherwise no validator is used by default.

This PR reinstates the validator registration, but adds a comment saying that the configuration for it is in the framework's passwords.yml file

Requires https://github.com/silverstripe/silverstripe-framework/pull/8604
Issue https://github.com/silverstripe/cwp-core/issues/52