### PR TITLE
Remove the configs for PasswordValidator

### DIFF
--- a/app/_config.php
+++ b/app/_config.php
@@ -1,10 +1,1 @@
 <?php
-
-use SilverStripe\Security\PasswordValidator;
-use SilverStripe\Security\Member;
-
-// remove PasswordValidator for SilverStripe 5.0
-$validator = PasswordValidator::create();
-$validator->setMinLength(8);
-$validator->setHistoricCount(6);
-Member::set_password_validator($validator);


### PR DESCRIPTION
The default PasswordValidator configs are in the framework now (_config/passwords.yml)

# Issue
 - https://github.com/silverstripe/silverstripe-framework/issues/8522