### PR TITLE
BUG Remove custom SS4.4 asset config to avoid breaking file migration on SS3 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - phpenv config-rm xdebug.ini
 
   - composer validate
-  - composer require --no-update silverstripe-themes/simple:~3.2.0 silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev silverstripe/cms:4.4.x-dev mikey179/vfsStream:^1.6
+  - composer require --no-update silverstripe-themes/simple:~3.2.0 silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev mikey179/vfsStream:^1.6
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --no-update; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=4.x-dev
+    - COMPOSER_ROOT_VERSION=4.4.x-dev
 
 matrix:
   include:
@@ -20,7 +20,7 @@ before_script:
   - phpenv config-rm xdebug.ini
 
   - composer validate
-  - composer require --no-update silverstripe-themes/simple:~3.2.0 silverstripe/admin:1.x-dev silverstripe/versioned:1.x-dev mikey179/vfsStream:^1.6
+  - composer require --no-update silverstripe-themes/simple:~3.2.0 silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev silverstripe/cms:4.4.x-dev mikey179/vfsStream:^1.6
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --no-update; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 


### PR DESCRIPTION
This is the parent PR to https://github.com/silverstripe/silverstripe-installer/pull/253

We're reverting the change introduce by https://github.com/silverstripe/recipe-core/pull/40. If you are upgrading from SS4.3 to SS4.4 you would not get the changes, which was the intended behaviour.

However, if upgrading from SS3 to SS4.4, you would be missing the legacy file ID helper, which would prevent you from running the file migration task.

