### PR TITLE
ENH | remove ErrorControlChainMiddleware from index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,7 +3,6 @@
 use SilverStripe\Control\HTTPApplication;
 use SilverStripe\Control\HTTPRequestBuilder;
 use SilverStripe\Core\CoreKernel;
-use SilverStripe\Core\Startup\ErrorControlChainMiddleware;
 
 // Find autoload.php
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
@@ -22,6 +21,5 @@ $request = HTTPRequestBuilder::createFromEnvironment();
 // Default application
 $kernel = new CoreKernel(BASE_PATH);
 $app = new HTTPApplication($kernel);
-$app->addMiddleware(new ErrorControlChainMiddleware($app));
 $response = $app->handle($request);
 $response->output();


### PR DESCRIPTION
deprecated since 4.4 and it's not necessary anymore