### PR TITLE
NEW Add MIME type validation out of the box

### DIFF
--- a/app/_config/mimevalidator.yml
+++ b/app/_config/mimevalidator.yml
@@ -1,0 +1,8 @@
+---
+Name: mimeuploadvalidator
+Only:
+  moduleexists: 'silverstripe/mimevalidator'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Assets\Upload_Validator:
+    class: SilverStripe\MimeValidator\MimeUploadValidator

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "silverstripe/recipe-plugin": "^1.2",
         "silverstripe/assets": "1.x-dev",
         "silverstripe/config": "1.0.x-dev",
-        "silverstripe/framework": "4.x-dev"
+        "silverstripe/framework": "4.x-dev",
+        "silverstripe/mimevalidator": "2.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
We've decided to make `silverstripe/mimevalidator` part of the core recipe from the 4.6. release onwards.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/8782

# Related PRs
- [ ] https://github.com/silverstripe/cwp/pull/268
- [ ] https://github.com/silverstripe/cwp-recipe-core/pull/14
- [ ] https://github.com/silverstripe/silverstripe-framework/pull/9505