### PR TITLE
Update minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "silverstripe/recipe-plugin": "^1.2",
         "silverstripe/assets": "1.6.x-dev",
-        "silverstripe/config": "1.1.x-dev",
+        "silverstripe/config": "1.0.x-dev",
         "silverstripe/framework": "4.6.x-dev",
         "silverstripe/mimevalidator": "2.0.x-dev"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/recipe-plugin": "^1.2",
-        "silverstripe/assets": "1.x-dev",
-        "silverstripe/config": "1.0.x-dev",
-        "silverstripe/framework": "4.x-dev",
-        "silverstripe/mimevalidator": "2.x-dev"
+        "silverstripe/assets": "1.6.x-dev",
+        "silverstripe/config": "1.1.x-dev",
+        "silverstripe/framework": "4.6.x-dev",
+        "silverstripe/mimevalidator": "2.0.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
Note: I've also bumped `silverstripe/config` to `1.1.x-dev`, was `1.0.x-dev` in `4.5`