### PR TITLE
BUG Revert "Disable uneeded File ID Helper on new project"

### DIFF
--- a/app/_config/mysite.yml
+++ b/app/_config/mysite.yml
@@ -3,29 +3,3 @@ Name: myproject
 ---
 SilverStripe\Core\Manifest\ModuleManifest:
   project: app
-
-
----
-Name: my-project-assetsflysystem
-After: '#assetsflysystem'
----
-# SilverStripe 4.4 changes the way files are resolved. `silverstripe-assets` resolves files using a variety of formats
-# by default. When starting a brand new project on SilverStripe 4.4 or greater, those extra formats are not needed and
-# will slowdown file resolution requests a bit. This config removes those redundant formats.
-SilverStripe\Core\Injector\Injector:
-  # Define public resolution strategy
-  SilverStripe\Assets\FilenameParsing\FileResolutionStrategy.public:
-    class: SilverStripe\Assets\FilenameParsing\FileIDHelperResolutionStrategy
-    properties:
-      ResolutionFileIDHelpers:
-        - '%$SilverStripe\Assets\FilenameParsing\HashFileIDHelper'
-      DefaultFileIDHelper: '%$SilverStripe\Assets\FilenameParsing\NaturalFileIDHelper'
-      VersionedStage: Live
-  # Define protected resolution strategy
-  SilverStripe\Assets\FilenameParsing\FileResolutionStrategy.protected:
-    class: SilverStripe\Assets\FilenameParsing\FileIDHelperResolutionStrategy
-    properties:
-      DefaultFileIDHelper: '%$SilverStripe\Assets\FilenameParsing\HashFileIDHelper'
-      ResolutionFileIDHelpers:
-        - '%$SilverStripe\Assets\FilenameParsing\HashFileIDHelper'
-      VersionedStage: Stage


### PR DESCRIPTION
This bit of code unnecessary duplicates https://github.com/silverstripe/silverstripe-installer/blob/4/app/_config/assets.yml

# Parent issue
https://github.com/silverstripe/silverstripe-installer/issues/277