### PR TITLE
MNT: Update recipe-core to config 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "silverstripe/recipe-plugin": "^1.2",
         "silverstripe/assets": "1.x-dev",
-        "silverstripe/config": "1.0.x-dev",
+        "silverstripe/config": "1.1.x-dev",
         "silverstripe/framework": "4.x-dev",
         "silverstripe/mimevalidator": "2.x-dev"
     },


### PR DESCRIPTION
Config 1.1 allows for Symfony 4 support, currently part of 1.1.x-dev.

Note that the CMS build framework test suite relies on recipe-cms, which relies on recipe-core.

As such this will be necessary to get a full pass on https://github.com/silverstripe/silverstripe-framework/pull/9698