### PR TITLE
FIX Make UTF-MB4 collation / charset default opt-in

### DIFF
--- a/app/_config/database.yml
+++ b/app/_config/database.yml
@@ -1,8 +1,0 @@
----
-Name: myproject-database
----
-SilverStripe\ORM\Connect\MySQLDatabase:
-  connection_charset: utf8mb4
-  connection_collation: utf8mb4_unicode_ci
-  charset: utf8mb4
-  collation: utf8mb4_unicode_ci

--- a/app/_config/mysite.yml
+++ b/app/_config/mysite.yml
@@ -3,3 +3,14 @@ Name: myproject
 ---
 SilverStripe\Core\Manifest\ModuleManifest:
   project: app
+
+# UTF8MB4 has limited support in older MySQL versions.
+# Remove this configuration if you experience issues.
+---
+Name: myproject-database
+---
+SilverStripe\ORM\Connect\MySQLDatabase:
+  connection_charset: utf8mb4
+  connection_collation: utf8mb4_unicode_ci
+  charset: utf8mb4
+  collation: utf8mb4_unicode_ci


### PR DESCRIPTION
This was originally intended as an opt-in change in Recipe 4.7.0, but was making its way into projects during upgrades due to its placement in a separate config file.

Related: https://github.com/silverstripe/silverstripe-framework/issues/9811