### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## SilverStripe Core Recipe
+## Silverstripe Core Recipe
 
-Base framework-only recipe for a SilverStripe ([http://silverstripe.org](http://silverstripe.org)) installation.
+Base framework-only recipe for a Silverstripe ([http://silverstripe.org](http://silverstripe.org)) installation.
 This includes the core modules:
 
  * [framework](http://github.com/silverstripe/silverstripe-framework): Module including the base framework
@@ -11,4 +11,4 @@ This can be either added to an existing project or used as a project base for cr
 basic framework-only install.
 
 See the [recipe plugin](https://github.com/silverstripe/recipe-plugin) page for instructions on how
-SilverStripe recipes work.
+Silverstripe recipes work.


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150061064-162d1161-1070-4650-bc41-e248727210a6.png)

See also silverstripe/silverstripe-framework#10206