### PR TITLE
MNT Reorder unit tests to fix CI failure

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="recipe-core">
+            <directory>vendor/silverstripe/framework/tests</directory>
             <directory>vendor/silverstripe/assets/tests</directory>
             <directory>vendor/silverstripe/config/tests</directory>
-            <directory>vendor/silverstripe/framework/tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
There seems to be some bleed-over of test config that didn't get torn down correctly from the assets unit tests which is causing a framework test to fail. The test is valid, and should pass on its own merits, so this is a valid way to resolve the CI issue for now.

Fixes https://github.com/silverstripe/recipe-core/actions/runs/2728729220
> 1) SilverStripe\ORM\Tests\DataObjectTest::testTableBuiltForInjectedDataObject
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'SilverStripe\ORM\Tests\DataObjectTest\InjectedDataObject'
+'SilverStripe\ORM\Tests\DataObjectTest\OverriddenDataObject'

## Parent issue
- https://github.com/silverstripe/gha-ci/issues/37