### PR TITLE
Test - force composer/installers 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,103 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "silverstripe/recipe-plugin": "^2",
-        "silverstripe/assets": "2.x-dev",
-        "silverstripe/config": "2.x-dev",
-        "silverstripe/framework": "5.x-dev",
-        "silverstripe/mimevalidator": "3.x-dev"
+        "silverstripe/recipe-plugin": "2.9.9 as 1.9.9",
+        "silverstripe/vendor-plugin": "2.9.9 as 1.9.9",
+        "silverstripe/assets": "1.11.0",
+        "silverstripe/config": "1.4.0",
+        "silverstripe/framework": "4.11.0",
+        "silverstripe/mimevalidator": "2.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "silverstripe/versioned": "^2",
+        "silverstripe/versioned": "^1",
         "mikey179/vfsstream": "^1.6.11"
+    },
+    "repositories": {
+        "x1": {
+            "type": "package",
+            "package": {
+                "version": "2.9.9",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/silverstripe/recipe-plugin/archive/refs/heads/1.zip"
+                },
+                "name": "silverstripe/recipe-plugin",
+                    "description": "Helper plugin to install SilverStripe recipes",
+                    "type": "composer-plugin",
+                    "license": "BSD-3-Clause",
+                    "authors": [
+                        {
+                            "name": "Damian Mooyman",
+                            "email": "damian@silverstripe.com"
+                        }
+                    ],
+                    "autoload": {
+                        "psr-4": {
+                            "SilverStripe\\RecipePlugin\\": "src/"
+                        }
+                    },
+                    "extra": {
+                        "class": "SilverStripe\\RecipePlugin\\RecipePlugin"
+                    },
+                    "scripts": {
+                        "lint": "phpcs src/",
+                        "lint-clean": "phpcbf src/"
+                    },
+                    "require": {
+                        "php": "^8.1",
+                        "composer-plugin-api": "^2"
+                    },
+                    "require-dev": {
+                        "composer/composer": "^2",
+                        "squizlabs/php_codesniffer": "^3.5"
+                    },
+                    "minimum-stability": "dev"
+            }
+        },
+        "x2": {
+            "type": "package",
+            "package": {
+                "version": "2.9.9",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/silverstripe/vendor-plugin/archive/refs/heads/1.zip"
+                },
+                "name": "silverstripe/vendor-plugin",
+                "description": "Allows vendor modules to expose directories to the webroot",
+                "type": "composer-plugin",
+                "license": "BSD-3-Clause",
+                "authors": [
+                    {
+                        "name": "Damian Mooyman",
+                        "email": "damian@silverstripe.com"
+                    }
+                ],
+                "autoload": {
+                    "psr-4": {
+                        "SilverStripe\\VendorPlugin\\": "src/",
+                        "SilverStripe\\VendorPlugin\\Tests\\": "tests/"
+                    }
+                },
+                "extra": {
+                    "class": "SilverStripe\\VendorPlugin\\VendorPlugin"
+                },
+                "scripts": {
+                    "lint": "phpcs src/ tests/",
+                    "lint-clean": "phpcbf src/ tests/"
+                },
+                "require": {
+                    "composer/installers": "^1.4",
+                    "composer-plugin-api": "^2",
+                    "php": "^7.4 || ^8"
+                },
+                "require-dev": {
+                    "composer/composer": "^1.5 || ^2@rc",
+                    "phpunit/phpunit": "^9.5",
+                    "squizlabs/php_codesniffer": "^3"
+                }
+            }
+        }
     },
     "extra": {
         "project-files": [


### PR DESCRIPTION
Test only, do not merge

Issue is lots of the following exception in the assets portion of unit tests:
`LogicException: getItemPath returned null for SilverStripe\Dev\State\FixtureTestState. Try adding flush=1 to the test run.`

Tried aliasing composer/installers v1.12.0 as v2.1.1 - did not fix issue 

...

Tried to alias silverstripe/framework 4.11.6 as 5.0.0 - did not install

...

Tried to install silverstripe/framework#7b0957709d6f972122617245147181668c84d8c6 (4.x-dev) using special composer.json repositories.package of silverstripe/framework 5.9.9 - did not fix issue

...

Trying "composer-plugin-api": "1.10.0 as 2.3.0" (test reverting silverstripe/recipe-plugin - https://github.com/silverstripe/recipe-plugin/compare/1...2)

