### PR TITLE
ENH Pull .htaccess file when required as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "extra": {
         "project-files": [
+            ".htaccess",
             "app/*"
         ],
         "public-files": [


### PR DESCRIPTION
Now that the public directory is mandatory, we must make sure we're pulling in `.htaccess` whenever recipe-core is included as a dependency to ensure apache traffic flows through that folder.

Any project using `composer create-project silverstripe/recipe-core` will have `.htaccess` in the project root by default, but using any other recipe (e.g. `composer create-project silverstripe/recipe-blog` or some custom bespoke recipe), or when adding `silverstripe/installer` as a dependency in CI, it needs to be included by `silverstripe/recipe-plugin` which this PR ensures will happen.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/642