### PR TITLE
MNT Remove unnecessary code

### DIFF
--- a/app/_config.php
+++ b/app/_config.php
@@ -1,9 +1,0 @@
-<?php
-
-use SilverStripe\Security\PasswordValidator;
-use SilverStripe\Security\Member;
-
-// remove PasswordValidator for SilverStripe 5.0
-$validator = PasswordValidator::create();
-// Settings are registered via Injector configuration - see passwords.yml in framework
-Member::set_password_validator($validator);


### PR DESCRIPTION
Issue https://github.com/silverstripe/recipe-core/issues/84

This file is copied to `app/_config.php` on `composer create-project`

I've validated locally using 2 methods that removing these lines from `app/_config.php` makes not difference to behaviour:
a) Changing a password in security admin
b) Debugging with a breakpoint [here](https://github.com/silverstripe/silverstripe-framework/blob/4.13/src/Security/Member.php#L435) - there is still a PasswordValidator create by Injector.

I also validated that calling `Member::set_password_validator(null);` in `app/_config.php` will result in no password validator being present, meaning that I could set a password of "a" in SecurityAdmin
