### PR TITLE
ENH Remove old logic to default UTF8 DB setting to 4 bytes

### DIFF
--- a/app/_config/mysite.yml
+++ b/app/_config/mysite.yml
@@ -3,14 +3,3 @@ Name: myproject
 ---
 SilverStripe\Core\Manifest\ModuleManifest:
   project: app
-
-# UTF8MB4 has limited support in older MySQL versions.
-# Remove this configuration if you experience issues.
----
-Name: myproject-database
----
-SilverStripe\ORM\Connect\MySQLDatabase:
-  connection_charset: utf8mb4
-  connection_collation: utf8mb4_unicode_ci
-  charset: utf8mb4
-  collation: utf8mb4_unicode_ci


### PR DESCRIPTION
## Description
Remove pointless setting in default project config to update UTF8 setting in DB

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/11336

## Related PR
- https://github.com/silverstripe/silverstripe-framework/pull/11431
- https://github.com/silverstripe/developer-docs/pull/602

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
