### PR TITLE
DEP Explicitly require and test silverstripe/template-engine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "silverstripe/assets": "3.x-dev",
         "silverstripe/config": "3.x-dev",
         "silverstripe/framework": "6.x-dev",
-        "silverstripe/mimevalidator": "4.x-dev"
+        "silverstripe/mimevalidator": "4.x-dev",
+        "silverstripe/template-engine": "1.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
             <directory>vendor/silverstripe/framework/tests</directory>
             <directory>vendor/silverstripe/assets/tests</directory>
             <directory>vendor/silverstripe/config/tests</directory>
+            <directory>vendor/silverstripe/template-engine/tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Ensures template engine gets both included in cow and tested against in a recipe.

CI for this can't go green until https://github.com/silverstripe/silverstripe-framework/pull/11451 has been merged

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322