### PR TITLE
DEP Use correct dep for recipe-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.3",
-        "silverstripe/recipe-plugin": "2.0.x-dev",
+        "silverstripe/recipe-plugin": "2.1.x-dev",
         "silverstripe/assets": "3.0.x-dev",
         "silverstripe/config": "3.0.x-dev",
         "silverstripe/framework": "6.0.x-dev",


### PR DESCRIPTION
This is the version included in 5.4, so it's the version we need to use here in lieu of a new major.

This constraint is causing cow to dislike me.

## Issue

- https://github.com/silverstripe/.github/issues/382